### PR TITLE
Added 60dB integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ Interview Assistant 是一款基于 Electron 的应用，可以捕获系统音�
 
 ## 为什么是Interview Assistant
 
-1. **实时语音转文字**: 利用 Deepgram API 实现实时语音识别。
-2. **智能 GPT 回答**: 集成 OpenAI 的 GPT 模型，为面试问题提供即时、智能的回答建议。(支持带转发地址的第三方API)
-3. **内容管理**: 用户可以上传自己的文件，包括文本、图片和 PDF 文件，和你自己定制的提示词，可以极大的定制你想要GPT回应的风格，这些资料将用于个性化 GPT 的回答。
-4. **统一上下文**: 在实时回答页面中，对话基于知识页面的配置，都在同一个上下文中进行，确保回答的连贯性和相关性。
-5. **跨平台支持**: 作为 Electron 应用，可以在 Windows、macOS系统上运行。
+1. **实时语音转文字**: 支持 **Deepgram** 和 **60db** 两种实时语音识别引擎，可在设置页面自由切换。
+2. **语音播报回答 (TTS)**: 集成 60db 文字转语音，可朗读 GPT 的回答建议（手动播放或自动播放，建议搭配耳机使用，避免被会议麦克风采集）。
+3. **智能 GPT 回答**: 集成 OpenAI 的 GPT 模型，为面试问题提供即时、智能的回答建议。(支持带转发地址的第三方API)
+4. **内容管理**: 用户可以上传自己的文件，包括文本、图片和 PDF 文件，和你自己定制的提示词，可以极大的定制你想要GPT回应的风格，这些资料将用于个性化 GPT 的回答。
+5. **统一上下文**: 在实时回答页面中，对话基于知识页面的配置，都在同一个上下文中进行，确保回答的连贯性和相关性。
+6. **跨平台支持**: 作为 Electron 应用，可以在 Windows、macOS系统上运行。
 
 ## 演示
 
@@ -45,7 +46,7 @@ Interview Assistant 相比其他面试辅助工具有以下优势：
 
 1. 从 Release 页面下载适合您操作系统的安装包。
 2. 运行 Interview Assistant。
-3. 在设置页面配置您的 OpenAI API 密钥和 Deepgram API 密钥。
+3. 在设置页面配置您的 OpenAI API 密钥，以及语音识别引擎的密钥（Deepgram 或 60db）。
 4. 开始使用实时面试辅助功能或管理您的知识库。
 
 ## 配置说明
@@ -53,7 +54,10 @@ Interview Assistant 相比其他面试辅助工具有以下优势：
 要使用 Interview Assistant，您需要：
 
 1. OpenAI API 密钥: 可以从 https://platform.openai.com 获取，或者可以购买第三方带有转发地址的API也同样支持，记得选择转发的复选框，配置完成后可以点击测试按钮进行测试。
-2. Deepgram API 密钥: 请访问 https://deepgram.com 注册并获取，新用户有200美元的免费额度，首页教程简单。
+2. 语音识别引擎（二选一，可在设置页面切换）：
+   - **Deepgram API 密钥**: 请访问 https://deepgram.com 注册并获取，新用户有200美元的免费额度，首页教程简单。
+   - **60db API 密钥**: 请访问 https://60db.ai 注册并获取（文档见 https://docs.60db.ai）。该密钥同时用于「语音播报回答 (TTS)」功能。
+3. 60db 语音播报 (可选): 选择 60db 密钥后，可在设置页面点击「Load Voices」加载可用音色，并勾选「Auto-speak GPT answers」开启自动朗读。
 
 ![image-20240919163506505](https://cdn.jsdelivr.net/gh/filifili233/blogimg@master/uPic/image-20240919163506505.png)
 
@@ -79,11 +83,12 @@ Interview Assistant is an Electron-based application that captures system audio 
 
 ## Why Interview Assistant
 
-1. **Real-time Speech-to-Text**: Utilizes Deepgram API for real-time speech recognition.
-2. **Intelligent GPT Responses**: Integrates OpenAI's GPT model to provide instant, intelligent answer suggestions for interview questions. (Supports third-party APIs with forwarding addresses)
-3. **Content Management**: Users can upload their own files, including text, images, and PDF files, along with customized prompts, greatly customizing the style of GPT responses. These materials will be used to personalize GPT's answers.
-4. **Unified Context**: In the real-time response page, conversations are based on the knowledge page configuration, all within the same context, ensuring coherence and relevance of answers.
-5. **Cross-platform Support**: As an Electron application, it can run on Windows and macOS systems.
+1. **Real-time Speech-to-Text**: Supports two real-time speech recognition engines — **Deepgram** and **60db** — switchable from the Settings page.
+2. **Spoken Answers (TTS)**: Integrates 60db Text-to-Speech to read GPT answer suggestions aloud (manual or auto-play; best used with headphones so the playback isn't picked up by the meeting mic).
+3. **Intelligent GPT Responses**: Integrates OpenAI's GPT model to provide instant, intelligent answer suggestions for interview questions. (Supports third-party APIs with forwarding addresses)
+4. **Content Management**: Users can upload their own files, including text, images, and PDF files, along with customized prompts, greatly customizing the style of GPT responses. These materials will be used to personalize GPT's answers.
+5. **Unified Context**: In the real-time response page, conversations are based on the knowledge page configuration, all within the same context, ensuring coherence and relevance of answers.
+6. **Cross-platform Support**: As an Electron application, it can run on Windows and macOS systems.
 
 ## Demo
 
@@ -115,7 +120,7 @@ This comparison table clearly shows the advantages of Interview Assistant compar
 
 1. Download the installation package suitable for your operating system from the Release page.
 2. Run Interview Assistant.
-3. Configure your OpenAI API key and Deepgram API key on the settings page.
+3. Configure your OpenAI API key and a speech recognition key (Deepgram or 60db) on the settings page.
 4. Start using the real-time interview assistance feature or manage your knowledge base.
 
 ## Configuration Instructions
@@ -123,7 +128,10 @@ This comparison table clearly shows the advantages of Interview Assistant compar
 To use Interview Assistant, you need:
 
 1. OpenAI API key: Can be obtained from https://platform.openai.com, or you can purchase a third-party API with a forwarding address which is also supported. Remember to select the forwarding checkbox, and you can click the test button to test after configuration.
-2. Deepgram API key: Please visit https://deepgram.com to register and obtain. New users get $200 free credit, and the homepage tutorial is simple.
+2. A speech recognition engine (pick one, switchable on the Settings page):
+   - **Deepgram API key**: Please visit https://deepgram.com to register and obtain. New users get $200 free credit, and the homepage tutorial is simple.
+   - **60db API key**: Register at https://60db.ai (docs at https://docs.60db.ai). This same key also powers the "Spoken Answers (TTS)" feature.
+3. 60db Text-to-Speech (optional): After entering a 60db key, click "Load Voices" in Settings to fetch available voices, and enable "Auto-speak GPT answers" to have answers read aloud automatically.
 
 ![image-20240919163506505](https://cdn.jsdelivr.net/gh/filifili233/blogimg@master/uPic/image-20240919163506505.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-interview-assistant",
+  "name": "interview-assistant",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-interview-assistant",
+      "name": "interview-assistant",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -15,6 +15,7 @@
         "@reduxjs/toolkit": "^2.2.7",
         "@types/node-fetch": "^2.6.11",
         "@types/react-router-dom": "^5.3.3",
+        "@types/ws": "^8.18.1",
         "axios": "^1.7.7",
         "cross-fetch": "^4.0.0",
         "daisyui": "^4.12.10",
@@ -35,7 +36,8 @@
         "react-router-dom": "^6.26.2",
         "react-syntax-highlighter": "^15.5.0",
         "sharp": "^0.33.5",
-        "tailwindcss": "^3.4.11"
+        "tailwindcss": "^3.4.11",
+        "ws": "^8.21.0"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.4.0",
@@ -275,27 +277,6 @@
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
-      }
-    },
-    "node_modules/@deepgram/sdk/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@derhuerst/http-basic": {
@@ -2404,10 +2385,9 @@
       "optional": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
-      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
-      "dev": true,
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -7455,6 +7435,28 @@
       },
       "peerDependencies": {
         "express": "^4.0.0 || ^5.0.0-alpha.1"
+      }
+    },
+    "node_modules/express-ws/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -16728,28 +16730,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/webpack-merge": {
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
@@ -17037,17 +17017,16 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@reduxjs/toolkit": "^2.2.7",
     "@types/node-fetch": "^2.6.11",
     "@types/react-router-dom": "^5.3.3",
+    "@types/ws": "^8.18.1",
     "axios": "^1.7.7",
     "cross-fetch": "^4.0.0",
     "daisyui": "^4.12.10",
@@ -37,7 +38,8 @@
     "react-router-dom": "^6.26.2",
     "react-syntax-highlighter": "^15.5.0",
     "sharp": "^0.33.5",
-    "tailwindcss": "^3.4.11"
+    "tailwindcss": "^3.4.11",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import fs from "fs";
 import path from "path";
 import { Buffer } from "buffer";
 import { createClient, LiveTranscriptionEvents } from "@deepgram/sdk";
+import WebSocket from "ws";
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 import electronSquirrelStartup from "electron-squirrel-startup";
@@ -217,6 +218,10 @@ app.on("before-quit", () => {
     api_call_method: config.api_call_method || "direct",
     primaryLanguage: config.primaryLanguage || "en",
     deepgram_api_key: config.deepgram_api_key || "",
+    stt_provider: config.stt_provider || "deepgram",
+    sixtydb_api_key: config.sixtydb_api_key || "",
+    sixtydb_voice_id: config.sixtydb_voice_id || "",
+    tts_autoplay: config.tts_autoplay || false,
   };
   store.clear();
   store.set("config", apiInfo);
@@ -408,86 +413,293 @@ function normalizeApiBaseUrl(url: string): string {
   return url;
 }
 
+// ---------------------------------------------------------------------------
+// Real-time Speech-to-Text (provider-agnostic)
+// ---------------------------------------------------------------------------
+// The renderer talks to a single set of channels (start-stt / send-audio /
+// stop-stt) and listens for unified events (stt-transcript / stt-status /
+// stt-error). Internally we route to either Deepgram (via @deepgram/sdk) or
+// 60db (via a raw WebSocket). Both expect 16 kHz, mono, 16-bit linear PCM,
+// which is exactly what InterviewPage produces.
+
+// Active connections. Only one provider is active at a time.
 let deepgramConnection: any = null;
+let sixtydbSocket: WebSocket | null = null;
+let activeProvider: "deepgram" | "60db" | null = null;
 
-ipcMain.handle("start-deepgram", async (event, config) => {
-  try {
-    if (!config.deepgram_key) {
-      throw new Error("Deepgram API key lose");
-    }
-    const deepgram = createClient(config.deepgram_key);
-    deepgramConnection = deepgram.listen.live({
-      punctuate: true,
-      interim_results: false,
-      model: "general",
-      language: config.primaryLanguage || "en",
-      encoding: "linear16",
-      sample_rate: 16000,
-      endpointing: 1500,
-    });
+function startDeepgram(event: Electron.IpcMainInvokeEvent, config: any) {
+  if (!config.deepgram_key) {
+    throw new Error("Deepgram API key missing");
+  }
+  const deepgram = createClient(config.deepgram_key);
+  deepgramConnection = deepgram.listen.live({
+    punctuate: true,
+    interim_results: false,
+    model: "general",
+    language: config.primaryLanguage || "en",
+    encoding: "linear16",
+    sample_rate: 16000,
+    endpointing: 1500,
+  });
 
-    deepgramConnection.addListener(LiveTranscriptionEvents.Open, () => {
-      event.sender.send("deepgram-status", { status: "open" });
-    });
+  deepgramConnection.addListener(LiveTranscriptionEvents.Open, () => {
+    event.sender.send("stt-status", { status: "open", provider: "deepgram" });
+  });
 
-    deepgramConnection.addListener(LiveTranscriptionEvents.Close, () => {
-      event.sender.send("deepgram-status", { status: "closed" });
-    });
+  deepgramConnection.addListener(LiveTranscriptionEvents.Close, () => {
+    event.sender.send("stt-status", { status: "closed", provider: "deepgram" });
+  });
 
-    deepgramConnection.addListener(
-      LiveTranscriptionEvents.Transcript,
-      (data: any) => {
-        if (
-          data &&
-          data.is_final &&
-          data.channel &&
-          data.channel.alternatives &&
-          data.channel.alternatives[0]
-        ) {
-          const transcript = data.channel.alternatives[0].transcript;
-          if (transcript) {
-            event.sender.send("deepgram-transcript", {
-              transcript,
-              is_final: true,
-            });
-          }
+  deepgramConnection.addListener(
+    LiveTranscriptionEvents.Transcript,
+    (data: any) => {
+      if (
+        data &&
+        data.is_final &&
+        data.channel &&
+        data.channel.alternatives &&
+        data.channel.alternatives[0]
+      ) {
+        const transcript = data.channel.alternatives[0].transcript;
+        if (transcript) {
+          event.sender.send("stt-transcript", { transcript, is_final: true });
         }
       }
+    }
+  );
+
+  deepgramConnection.addListener(LiveTranscriptionEvents.Error, (err: any) => {
+    event.sender.send("stt-error", { provider: "deepgram", error: err });
+  });
+
+  return new Promise<void>((resolve, reject) => {
+    deepgramConnection.addListener(LiveTranscriptionEvents.Open, () =>
+      resolve()
+    );
+    deepgramConnection.addListener(LiveTranscriptionEvents.Error, reject);
+    setTimeout(() => reject(new Error("Deepgram timeout")), 10000);
+  });
+}
+
+function start60dbStt(event: Electron.IpcMainInvokeEvent, config: any) {
+  if (!config.sixtydb_key) {
+    throw new Error("60db API key missing");
+  }
+  const url = `wss://api.60db.ai/ws/stt?apiKey=${encodeURIComponent(
+    config.sixtydb_key
+  )}`;
+  const socket = new WebSocket(url);
+  sixtydbSocket = socket;
+
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("60db STT timeout")),
+      10000
     );
 
-    deepgramConnection.addListener(
-      LiveTranscriptionEvents.Error,
-      (err: any) => {
-        event.sender.send("deepgram-error", err);
-      }
-    );
-
-    await new Promise((resolve, reject) => {
-      deepgramConnection.addListener(LiveTranscriptionEvents.Open, resolve);
-      deepgramConnection.addListener(LiveTranscriptionEvents.Error, reject);
-      setTimeout(() => reject(new Error("Deepgram timeout")), 10000);
+    socket.on("open", () => {
+      // Tell 60db we will stream browser PCM (linear) at 16 kHz.
+      const language =
+        config.primaryLanguage && config.primaryLanguage !== "auto"
+          ? config.primaryLanguage
+          : "en";
+      socket.send(
+        JSON.stringify({
+          type: "start",
+          languages: [language],
+          config: {
+            encoding: "linear",
+            sample_rate: 16000,
+            utterance_end_ms: 1000,
+            continuous_mode: true,
+            interim_results_frequency: 0,
+            audio_enhancement: "adaptive",
+            diarize: false,
+          },
+        })
+      );
     });
 
+    socket.on("message", (raw: WebSocket.RawData) => {
+      let msg: any;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        return;
+      }
+
+      // Server is ready for audio.
+      if (msg.type === "connected") {
+        clearTimeout(timeout);
+        event.sender.send("stt-status", { status: "open", provider: "60db" });
+        resolve();
+        return;
+      }
+
+      // Final transcript. We only forward the canonical (speech_final) result
+      // with non-empty text, mirroring the Deepgram is_final filter.
+      if (
+        msg.type === "transcription" &&
+        msg.speech_final === true &&
+        msg.text &&
+        msg.text.trim()
+      ) {
+        event.sender.send("stt-transcript", {
+          transcript: msg.text,
+          is_final: true,
+        });
+        return;
+      }
+
+      if (msg.type === "error") {
+        event.sender.send("stt-error", { provider: "60db", error: msg });
+      }
+    });
+
+    socket.on("error", (err) => {
+      clearTimeout(timeout);
+      event.sender.send("stt-error", { provider: "60db", error: err.message });
+      reject(err);
+    });
+
+    socket.on("close", () => {
+      event.sender.send("stt-status", { status: "closed", provider: "60db" });
+    });
+  });
+}
+
+ipcMain.handle("start-stt", async (event, config) => {
+  try {
+    const provider: "deepgram" | "60db" =
+      config.stt_provider === "60db" ? "60db" : "deepgram";
+    activeProvider = provider;
+
+    if (provider === "60db") {
+      await start60dbStt(event, config);
+    } else {
+      await startDeepgram(event, config);
+    }
     return { success: true };
   } catch (error) {
+    activeProvider = null;
     return { success: false, error: error.message };
   }
 });
 
-ipcMain.handle("send-audio-to-deepgram", async (event, audioData) => {
-  if (deepgramConnection) {
-    try {
-      const buffer = Buffer.from(audioData);
+ipcMain.handle("send-audio", async (event, audioData) => {
+  try {
+    const buffer = Buffer.from(audioData);
+    if (activeProvider === "deepgram" && deepgramConnection) {
       deepgramConnection.send(buffer);
-    } catch (error) {
-      console.error("failed send data to Deepgram :", error);
+    } else if (
+      activeProvider === "60db" &&
+      sixtydbSocket &&
+      sixtydbSocket.readyState === WebSocket.OPEN
+    ) {
+      sixtydbSocket.send(
+        JSON.stringify({
+          type: "audio",
+          audio: buffer.toString("base64"),
+          encoding: "linear",
+          sample_rate: 16000,
+        })
+      );
     }
+  } catch (error) {
+    console.error("failed to send audio to STT provider:", error);
   }
 });
 
-ipcMain.handle("stop-deepgram", () => {
+ipcMain.handle("stop-stt", () => {
   if (deepgramConnection) {
-    deepgramConnection.finish();
+    try {
+      deepgramConnection.finish();
+    } catch {
+      /* ignore */
+    }
     deepgramConnection = null;
+  }
+  if (sixtydbSocket) {
+    try {
+      if (sixtydbSocket.readyState === WebSocket.OPEN) {
+        sixtydbSocket.send(JSON.stringify({ type: "stop" }));
+      }
+      sixtydbSocket.close();
+    } catch {
+      /* ignore */
+    }
+    sixtydbSocket = null;
+  }
+  activeProvider = null;
+});
+
+// ---------------------------------------------------------------------------
+// 60db Text-to-Speech + voices
+// ---------------------------------------------------------------------------
+
+ipcMain.handle("speak-60db", async (event, { text, config }) => {
+  try {
+    if (!config.sixtydb_api_key) {
+      throw new Error("60db API key missing");
+    }
+    if (!text || !text.trim()) {
+      throw new Error("No text to synthesize");
+    }
+    // Non-streaming synthesis: returns base64 audio in JSON. We default to mp3
+    // so the renderer can play it directly via a data: URI.
+    const response = await axios.post(
+      "https://api.60db.ai/tts-synthesize",
+      {
+        text: text.slice(0, 5000),
+        voice_id: config.sixtydb_voice_id || undefined,
+        output_format: "mp3",
+        speed: 1,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${config.sixtydb_api_key}`,
+          "Content-Type": "application/json",
+        },
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity,
+      }
+    );
+
+    const data = response.data || {};
+    if (!data.audio_base64) {
+      throw new Error(data.message || "60db returned no audio");
+    }
+    return {
+      success: true,
+      audio_base64: data.audio_base64,
+      output_format: data.output_format || "mp3",
+    };
+  } catch (error: any) {
+    const message = axios.isAxiosError(error)
+      ? error.response
+        ? `60db TTS error: ${error.response.status} ${error.response.statusText}`
+        : error.message
+      : error.message || "Unknown error";
+    return { success: false, error: message };
+  }
+});
+
+ipcMain.handle("get-60db-voices", async (event, config) => {
+  try {
+    if (!config.sixtydb_api_key) {
+      throw new Error("60db API key missing");
+    }
+    const response = await axios.get("https://api.60db.ai/myvoices", {
+      headers: { Authorization: `Bearer ${config.sixtydb_api_key}` },
+    });
+    const data = response.data || {};
+    return { success: true, voices: Array.isArray(data.data) ? data.data : [] };
+  } catch (error: any) {
+    const message = axios.isAxiosError(error)
+      ? error.response
+        ? `60db voices error: ${error.response.status} ${error.response.statusText}`
+        : error.message
+      : error.message || "Unknown error";
+    return { success: false, error: message, voices: [] };
   }
 });

--- a/src/pages/InterviewPage.tsx
+++ b/src/pages/InterviewPage.tsx
@@ -35,7 +35,47 @@ const InterviewPage: React.FC = () => {
   const [audioContext, setAudioContext] = useState<AudioContext | null>(null);
   const [processor, setProcessor] = useState<ScriptProcessorNode | null>(null);
   const [autoSubmitTimer, setAutoSubmitTimer] = useState<NodeJS.Timeout | null>(null);
+  const [isSpeaking, setIsSpeaking] = useState(false);
   const aiResponseRef = useRef<HTMLDivElement>(null);
+  const ttsAudioRef = useRef<HTMLAudioElement | null>(null);
+
+  const speakText = useCallback(async (text: string) => {
+    const trimmed = (text || "").trim();
+    if (!trimmed) return;
+    try {
+      const config = await window.electronAPI.getConfig();
+      if (!config.sixtydb_api_key) {
+        setError("60db API key not configured. Please add it in Settings to use Text-to-Speech.");
+        return;
+      }
+      setIsSpeaking(true);
+      const result = await window.electronAPI.speak60db(trimmed, config);
+      if (!result.success || !result.audio_base64) {
+        throw new Error(result.error || "Failed to synthesize speech");
+      }
+      // Stop any in-flight playback before starting the new clip.
+      if (ttsAudioRef.current) {
+        ttsAudioRef.current.pause();
+      }
+      const mime = result.output_format === "wav" ? "audio/wav" : result.output_format === "ogg" ? "audio/ogg" : "audio/mpeg";
+      const audio = new Audio(`data:${mime};base64,${result.audio_base64}`);
+      ttsAudioRef.current = audio;
+      audio.onended = () => setIsSpeaking(false);
+      audio.onerror = () => setIsSpeaking(false);
+      await audio.play();
+    } catch (err: any) {
+      setIsSpeaking(false);
+      setError(err?.message || "Failed to play Text-to-Speech audio.");
+    }
+  }, [setError]);
+
+  const stopSpeaking = useCallback(() => {
+    if (ttsAudioRef.current) {
+      ttsAudioRef.current.pause();
+      ttsAudioRef.current = null;
+    }
+    setIsSpeaking(false);
+  }, []);
 
   const markdownStyles = `
     .markdown-body {
@@ -100,6 +140,10 @@ const InterviewPage: React.FC = () => {
       addConversation({ role: "assistant", content: formattedResponse });
       setDisplayedAiResult(prev => prev + (prev ? '\n\n' : '') + formattedResponse);
       setLastProcessedIndex(currentText.length);
+
+      if (config.tts_autoplay && config.sixtydb_api_key) {
+        speakText(formattedResponse);
+      }
     } catch (error) {
       setError('Failed to get response from GPT. Please try again.');
     } finally {
@@ -156,11 +200,11 @@ const InterviewPage: React.FC = () => {
       checkTimer = setTimeout(checkAndSubmit, 1000);
     };
 
-    window.electronAPI.ipcRenderer.on('deepgram-transcript', handleDeepgramTranscript);
+    window.electronAPI.ipcRenderer.on('stt-transcript', handleDeepgramTranscript);
     checkTimer = setTimeout(checkAndSubmit, 1000);
 
     return () => {
-      window.electronAPI.ipcRenderer.removeListener('deepgram-transcript', handleDeepgramTranscript);
+      window.electronAPI.ipcRenderer.removeListener('stt-transcript', handleDeepgramTranscript);
       if (checkTimer) {
         clearTimeout(checkTimer);
       }
@@ -193,8 +237,11 @@ const InterviewPage: React.FC = () => {
       setUserMedia(stream);
 
       const config = await window.electronAPI.getConfig();
-      const result = await window.electronAPI.ipcRenderer.invoke('start-deepgram', {
-        deepgram_key: config.deepgram_api_key
+      const result = await window.electronAPI.ipcRenderer.invoke('start-stt', {
+        stt_provider: config.stt_provider || 'deepgram',
+        deepgram_key: config.deepgram_api_key,
+        sixtydb_key: config.sixtydb_api_key,
+        primaryLanguage: config.primaryLanguage,
       });
       if (!result.success) {
         throw new Error(result.error);
@@ -215,7 +262,7 @@ const InterviewPage: React.FC = () => {
         for (let i = 0; i < inputData.length; i++) {
           audioData[i] = Math.max(-1, Math.min(1, inputData[i])) * 0x7FFF;
         }
-        window.electronAPI.ipcRenderer.invoke('send-audio-to-deepgram', audioData.buffer);
+        window.electronAPI.ipcRenderer.invoke('send-audio', audioData.buffer);
       };
 
       setIsRecording(true);
@@ -234,7 +281,7 @@ const InterviewPage: React.FC = () => {
     if (processor) {
       processor.disconnect();
     }
-    window.electronAPI.ipcRenderer.invoke('stop-deepgram');
+    window.electronAPI.ipcRenderer.invoke('stop-stt');
     setIsRecording(false);
     setUserMedia(null);
     setAudioContext(null);
@@ -321,6 +368,13 @@ const InterviewPage: React.FC = () => {
               className="btn btn-primary"
             >
               {isLoading ? "Loading..." : "Ask GPT"}
+            </button>
+            <button
+              onClick={() => (isSpeaking ? stopSpeaking() : speakText(displayedAiResult))}
+              disabled={!displayedAiResult}
+              className="btn btn-secondary"
+            >
+              {isSpeaking ? "Stop" : "🔊 Speak"}
             </button>
             <button onClick={() => {
               setDisplayedAiResult("");

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -14,6 +14,12 @@ const Settings: React.FC = () => {
   const [primaryLanguage, setPrimaryLanguage] = useState('auto');
   const [secondaryLanguage, setSecondaryLanguage] = useState('');
   const [deepgramApiKey, setDeepgramApiKey] = useState('');
+  const [sttProvider, setSttProvider] = useState<'deepgram' | '60db'>('deepgram');
+  const [sixtydbApiKey, setSixtydbApiKey] = useState('');
+  const [sixtydbVoiceId, setSixtydbVoiceId] = useState('');
+  const [ttsAutoplay, setTtsAutoplay] = useState(false);
+  const [voices, setVoices] = useState<Array<{ voice_id: string; name: string; labels?: { language_name?: string; gender?: string; accent?: string } }>>([]);
+  const [voicesLoading, setVoicesLoading] = useState(false);
 
   useEffect(() => {
     loadConfig();
@@ -29,6 +35,10 @@ const Settings: React.FC = () => {
       setPrimaryLanguage(config.primaryLanguage || 'auto');
       setSecondaryLanguage(config.secondaryLanguage || '');
       setDeepgramApiKey(config.deepgram_api_key || '');
+      setSttProvider(config.stt_provider === '60db' ? '60db' : 'deepgram');
+      setSixtydbApiKey(config.sixtydb_api_key || '');
+      setSixtydbVoiceId(config.sixtydb_voice_id || '');
+      setTtsAutoplay(!!config.tts_autoplay);
     } catch (err) {
       console.error('Failed to load configuration', err);
       setError('Failed to load configuration. Please check your settings.');
@@ -44,11 +54,38 @@ const Settings: React.FC = () => {
         api_call_method: apiCallMethod,
         primaryLanguage: primaryLanguage,
         deepgram_api_key: deepgramApiKey,
+        stt_provider: sttProvider,
+        sixtydb_api_key: sixtydbApiKey,
+        sixtydb_voice_id: sixtydbVoiceId,
+        tts_autoplay: ttsAutoplay,
       });
       setSaveSuccess(true);
       setTimeout(() => setSaveSuccess(false), 3000);
     } catch (err) {
       setError('Failed to save configuration');
+    }
+  };
+
+  const loadVoices = async () => {
+    if (!sixtydbApiKey) {
+      setError('Enter your 60db API key first to load voices.');
+      return;
+    }
+    try {
+      setVoicesLoading(true);
+      const result = await window.electronAPI.get60dbVoices({ sixtydb_api_key: sixtydbApiKey });
+      if (result.success) {
+        setVoices(result.voices);
+        if (!result.voices.length) {
+          setError('No 60db voices found for this account.');
+        }
+      } else {
+        setError(`Failed to load 60db voices: ${result.error || 'Unknown error'}`);
+      }
+    } catch (err) {
+      setError('Failed to load 60db voices.');
+    } finally {
+      setVoicesLoading(false);
     }
   };
 
@@ -131,6 +168,20 @@ const Settings: React.FC = () => {
         </select>
       </div>
       <div className="mb-4">
+        <label className="label">Transcription Provider (STT)</label>
+        <select
+          value={sttProvider}
+          onChange={(e) => setSttProvider(e.target.value as 'deepgram' | '60db')}
+          className="select select-bordered w-full"
+        >
+          <option value="deepgram">Deepgram</option>
+          <option value="60db">60db</option>
+        </select>
+        <label className="label">
+          <span className="label-text-alt">Choose which engine transcribes the meeting audio in real time.</span>
+        </label>
+      </div>
+      <div className="mb-4">
         <label className="label">Deepgram API Key</label>
         <input
           type="password"
@@ -138,6 +189,53 @@ const Settings: React.FC = () => {
           onChange={(e) => setDeepgramApiKey(e.target.value)}
           className="input input-bordered w-full"
         />
+      </div>
+      <div className="mb-4">
+        <label className="label">60db API Key</label>
+        <input
+          type="password"
+          value={sixtydbApiKey}
+          onChange={(e) => setSixtydbApiKey(e.target.value)}
+          className="input input-bordered w-full"
+        />
+        <label className="label">
+          <span className="label-text-alt">Used for 60db transcription (if selected above) and for speaking answers aloud.</span>
+        </label>
+      </div>
+      <div className="mb-4">
+        <label className="label">60db Voice (Text-to-Speech)</label>
+        <div className="flex space-x-2">
+          <select
+            value={sixtydbVoiceId}
+            onChange={(e) => setSixtydbVoiceId(e.target.value)}
+            className="select select-bordered flex-1"
+          >
+            <option value="">System default</option>
+            {voices.map((v) => (
+              <option key={v.voice_id} value={v.voice_id}>
+                {v.name}
+                {v.labels?.language_name ? ` (${v.labels.language_name}${v.labels.accent ? `, ${v.labels.accent}` : ''})` : ''}
+              </option>
+            ))}
+          </select>
+          <button type="button" onClick={loadVoices} className="btn btn-outline" disabled={voicesLoading}>
+            {voicesLoading ? 'Loading...' : 'Load Voices'}
+          </button>
+        </div>
+      </div>
+      <div className="mb-4">
+        <label className="flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            checked={ttsAutoplay}
+            onChange={(e) => setTtsAutoplay(e.target.checked)}
+            className="checkbox mr-2"
+          />
+          <span>Auto-speak GPT answers (60db TTS)</span>
+        </label>
+        <label className="label">
+          <span className="label-text-alt">Best with headphones/a private output device, so playback isn&apos;t captured by the meeting.</span>
+        </label>
       </div>
       <div className="mb-4">
         <label className="label">Primary Language</label>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -18,6 +18,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     removeListener: (channel: string, listener: (event: any, ...args: any[]) => void) => ipcRenderer.removeListener(channel, listener),
   },
   callOpenAI: (params: any) => ipcRenderer.invoke('callOpenAI', params),
+  speak60db: (text: string, config: any) => ipcRenderer.invoke('speak-60db', { text, config }),
+  get60dbVoices: (config: any) => ipcRenderer.invoke('get-60db-voices', config),
   loadAudioProcessor: (): Promise<string> => ipcRenderer.invoke('load-audio-processor'),
   getSystemAudioStream: () => ipcRenderer.invoke('get-system-audio-stream'),
   transcribeAudioFile: (filePath: string, config: any) => ipcRenderer.invoke('transcribe-audio-file', filePath, config),

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -21,6 +21,8 @@ export interface ElectronAPI {
     signal?: AbortSignal;
   }) => Promise<{ content: string } | { error: string }>;
   transcribeAudio: (audioBuffer: ArrayBuffer, config: any) => Promise<TranscriptionResult>;
+  speak60db: (text: string, config: any) => Promise<{ success: boolean; audio_base64?: string; output_format?: string; error?: string }>;
+  get60dbVoices: (config: any) => Promise<{ success: boolean; voices: Array<{ voice_id: string; name: string; labels?: { language_name?: string; gender?: string; accent?: string } }>; error?: string }>;
 }
 
 declare global {


### PR DESCRIPTION
New capabilities
  - STT (input): 60db real-time transcription as an alternative to Deepgram, picked via a Settings dropdown — same audio pipeline   
  feeds either.
  - TTS (output): 60db reads GPT answers aloud (🔊 Speak button + optional auto-play).
  
  Code changes
  - index.ts — provider-agnostic STT (start-stt/send-audio/stop-stt + stt-transcript/stt-status/stt-error) routing to Deepgram or   
  the new wss://api.60db.ai/ws/stt socket; plus speak-60db (TTS) and get-60db-voices handlers.
  - preload.ts / renderer.d.ts — exposed speak60db() and get60dbVoices().
  - Settings.tsx — provider dropdown, 60db API key, voice dropdown + "Load Voices", auto-speak toggle.
  - InterviewPage.tsx — uses unified STT channels, Speak/Stop button, answer autoplay.
  - Added ws dependency; updated the README (both languages).

  New config keys: stt_provider, sixtydb_api_key, sixtydb_voice_id, tts_autoplay